### PR TITLE
1.21 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
 # No Kebab
+## Overview
+In vanilla Minecraft, when a painting is loaded with an ID that doesn't match any existing variant, it will be automatically replaced with another one. No questions asked. If you mess around with data-driven paintings, any error in your datapacks may cause already-placed paintings to be lost upon loading a world.
 
-Prevents paintings with unknown IDs from being irremediably turned into kebabs.
+No-Kebab serves as a safeguard against that. Invalid paintings will still fall back to a different variant, but they will remember the variant ID that was originally present in their NBT data, and keep that ID when saving the game. The next time you load that world with the correct set of variants installed, those painting will be restored to their original appearance.
 
-In vanilla Minecraft, any painting bearing an ID unknown to the registry will be reverted to the `minecraft:kebab` variant. No questions asked.  
-If you mess around with mods that add new paintings (especially user-defined paintings), any error may cause your existing paintings to be lost upon loading a world.
-
-No-Kebab serves as a safeguard against that. Invalid paintings will still appear as Kebab, but they will not forget the painting ID that was originally present in their NBT data, and keep that ID when saving the game. The next time you load that world with the correct set of variants installed, those painting will be restored to their original appearance.
+Trivia: Prior to MC 1.21, invalid paintings would invariably be reverted to the `minecraft:kebab` variant, hence the mod's name.
 
 ## Environment
 Core functionalities are **fully server-side**.
 
-Client-side installation only adds cosmetic changes to invalid painting, to makes them stand out and reveal their ID. Clients without the mod installed will still see invalid paintings as Kebabs.
+Client-side is required only if the **Missingno Display** feature is enabled.
 
-## Command
+## Missingno Display
+This changes the appearence of invalid paintings, making them stand out, and revealing their ID.
 
-The command `/nokebab migrate <mode> <source> <destination>` can be used to change the variant of existing paintings in bulk. It requires a permisssion level of 3 (Admin).
+By default, it will be **disabled on dedicated server**, and **enabled on integrated servers** (singleplayer and LA?). 
+This can be toggled in the config file `nokebab.properties`, with the option called `customTracker`. This requires a full restart to take effect.
+
+## Migration
+The command `/nokebab migrate` can be used to change the variant of existing paintings in bulk. It requires a permisssion level of 3 (Admin).
 
 **This will only change the variant of placed paintings in currently loaded chunks** Paintings in item form or in unloaded chunks will not be affected.
 
-If a migration would result in the painting no longer being able to fit, this painting will be skipped with an error message.
+If a migration would result in a painting no longer being able to fit its wall, this painting will be skipped with an error message.
 
 ### Synopsis
 `/nokebab migrate <mode> <source> <destination>`
 
-`<source>` is the variant of paintings that should be migrated. `<destination>` is the variant they will be replaced with. The specifics vary depending on the mode.
+`<source>` is the variant of paintings that should be migrated. `<destination>` is the variant they will be replaced with. Their specifics vary depending on the mode.
 
-`<mode>` can be either `literal` or `regex`.
-"Literal" will seek paintings that exactly match the source, and change them all to the same variant.
-"Regex" allows the use of Regular Expressions, so the source can match multiple variants, and the destination can use substitution variables.
+`<mode>` can be either:
+- `Literal`, will seek paintings that exactly match the source, and change them all to the same variant.
+- `Regex`, allows the use of Regular Expressions, so `<source>` can match multiple variants, and `<destination>` can use substitution variables.
 
 For example, the command to change the namespace of multiple paintings would be:
 ```
 /nokebab migrate regex "oldspace:(.*)" "newspace:$1"
 ```
-
-## Compatibility
-
-No-Kebab relies on and preserves the vanilla variant system; it will only work with mods that do not implement their own variant system.  
-This should also be compatible with mods that lets you change the variant of an already placed painting.
-
-No-Kebab is based off a feature from my experimental [Datapack-driven](https://modrinth.com/mod/dataified-paintings) paintings Mod, but was rewritten from the ground up into something much more stable. 
-Dataified-Paintings 1.0 will likeky not be compatible with it, so long as both mods include this feature.

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,6 @@ processResources {
 	filesMatching("fabric.mod.json") {
 		expand "version": project.version
 	}
-
-	exclude "**/*.xcf"
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -61,6 +59,10 @@ jar {
 	from("LICENSE") {
 		rename { "${it}_${project.base.archivesName.get()}"}
 	}
+
+	exclude "**/*.xcf"
+	exclude "**/*.psd"
+	exclude "**/*.psb"
 }
 
 // configure the maven publication

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
-loader_version=0.15.10
+minecraft_version=1.21
+yarn_mappings=1.21+build.1
+loader_version=0.15.11
 
-#Fabric api
-fabric_version=0.97.8+1.20.6
+# Fabric API
+fabric_version=0.100.1+1.21
 
 # Mod Properties
 mod_version=1.3.0

--- a/port.md
+++ b/port.md
@@ -13,3 +13,7 @@ Current master
 #### Possible Workaround
 - **Vanilla Clients now crash when receiving data from modded data trackers**. Use display entities instead ?
 - `PaintingEntity::VARIANT_NBT_KEY` was removed: Use literal instead.
+
+### 1.21.0
+#### No Workaround: 
+- The painting registry is no longer static, and must be passed into the parameters of the functions that need it.

--- a/port.md
+++ b/port.md
@@ -18,5 +18,5 @@ Current master
 #### No Workaround: 
 - The painting registry is no longer static, and must be passed into the parameters of the functions that need it.
 - The serialization function of paintings now use codecs. Requires new mixin injection.
-###	Possible Workaround: 
+### Possible Workaround: 
 - Invalid variant-locked painting no longer defaults to a specific variant.

--- a/port.md
+++ b/port.md
@@ -17,3 +17,6 @@ Current master
 ### 1.21.0
 #### No Workaround: 
 - The painting registry is no longer static, and must be passed into the parameters of the functions that need it.
+- The serialization function of paintings now use codecs. Requires new mixin injection.
+###	Possible Workaround: 
+- Invalid variant-locked painting no longer defaults to a specific variant.

--- a/src/main/java/tk/estecka/nokebab/Commands.java
+++ b/src/main/java/tk/estecka/nokebab/Commands.java
@@ -18,10 +18,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.entity.Entity;
-import net.minecraft.registry.Registries;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.CommandManager.RegistrationEnvironment;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -35,6 +35,7 @@ import static net.minecraft.server.command.CommandManager.literal;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.command.argument.EntityArgumentType.entities;
 import static net.minecraft.command.argument.EntityArgumentType.getEntities;
+import static tk.estecka.nokebab.RegistryUtil.*;
 
 public class Commands
 {
@@ -109,7 +110,7 @@ public class Commands
 	}
 
 	static private CompletableFuture<Suggestions> ValidPaintingSuggestion(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder){
-		for (Identifier id : Registries.PAINTING_VARIANT.getIds())
+		for (Identifier id : PaintingsOf(context.getSource().getWorld()).getIds())
 			SuggestWhenAppropriate(builder, id.toString());
 		return builder.buildFuture();
 	}
@@ -144,7 +145,8 @@ public class Commands
 		String src = getString(context, SRC_ARG);
 		String dst = getString(context, DST_ARG);
 
-		Migration.Result result = new Migration.Literal(src, dst).Run(context.getSource().getWorld().iterateEntities());
+		ServerWorld world = context.getSource().getWorld();
+		Migration.Result result = new Migration.Literal(src, dst, PaintingsOf(world)).Run(world.iterateEntities());
 		return SendFeedback(context, result, ServersideTranslatable(SUCCESS_MSG_LIT, result.success(), src, dst));
 	}
 
@@ -159,7 +161,8 @@ public class Commands
 			return -1;
 		}
 
-		Migration.Result result = new Migration.Regex(regex, substitution).Run(context.getSource().getWorld().iterateEntities());
+		ServerWorld world = context.getSource().getWorld();
+		Migration.Result result = new Migration.Regex(regex, substitution, PaintingsOf(world)).Run(world.iterateEntities());
 		return SendFeedback(context, result, ServersideTranslatable(SUCCESS_MSG, result.success()));
 	}
 

--- a/src/main/java/tk/estecka/nokebab/Migration.java
+++ b/src/main/java/tk/estecka/nokebab/Migration.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
+import net.minecraft.entity.decoration.painting.PaintingVariant;
+import net.minecraft.registry.Registry;
 
 public abstract class Migration
 implements Function<PaintingEntity, PaintingState>
@@ -68,9 +70,9 @@ implements Function<PaintingEntity, PaintingState>
 		private final String source;
 		private final PaintingState destination;
 
-		public Literal(String source, String destination){
+		public Literal(String source, String destination, Registry<PaintingVariant> registry){
 			this.source = source;
-			this.destination = PaintingState.ForName(destination);
+			this.destination = PaintingState.ForName(destination, registry);
 		}
 
 		public boolean Matches(PaintingEntity painting){
@@ -88,10 +90,12 @@ implements Function<PaintingEntity, PaintingState>
 	{
 		private final Pattern source;
 		private final String destination;
+		private final Registry<PaintingVariant> registry;
 
-		public Regex(Pattern source, String destination){
+		public Regex(Pattern source, String destination, Registry<PaintingVariant> registry){
 			this.source = source;
 			this.destination = destination;
+			this.registry = registry;
 		}
 
 		@Override
@@ -101,7 +105,7 @@ implements Function<PaintingEntity, PaintingState>
 			if (!match.matches())
 				return null;
 			else
-				return PaintingState.ForName(match.replaceAll(this.destination));
+				return PaintingState.ForName(match.replaceAll(this.destination), registry);
 		}
 	}
 }

--- a/src/main/java/tk/estecka/nokebab/PaintingState.java
+++ b/src/main/java/tk/estecka/nokebab/PaintingState.java
@@ -3,7 +3,7 @@ package tk.estecka.nokebab;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import net.minecraft.entity.decoration.painting.PaintingVariant;
-import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
@@ -23,32 +23,32 @@ import net.minecraft.util.Identifier;
  */
 public record PaintingState (@NotNull String missingName, @NotNull RegistryEntry<PaintingVariant> activeVariant)
 {
-	static public PaintingState ForName(String variantName){
-		return FromEntry(variantName, GetEntry(variantName));
+	static public PaintingState ForName(String variantName, Registry<PaintingVariant> registry){
+		return FromEntry(variantName, GetEntry(variantName, registry), registry);
 	}
-	static public PaintingState ForId(Identifier variantId){
-		return FromEntry(variantId.toString(), GetEntry(variantId));
+	static public PaintingState ForId(Identifier variantId, Registry<PaintingVariant> registry){
+		return FromEntry(variantId.toString(), GetEntry(variantId, registry), registry);
 	}
-	static private PaintingState FromEntry(String name, @Nullable RegistryEntry<PaintingVariant> entry){
+	static private PaintingState FromEntry(String name, @Nullable RegistryEntry<PaintingVariant> entry, Registry<PaintingVariant> registry){
 		if (entry != null)
 			return new PaintingState("", entry);
 		else
-			return new PaintingState(name, GetEntry(Registries.PAINTING_VARIANT.getDefaultId()));
+			return new PaintingState(name, registry.getDefaultEntry().orElseThrow());
 	}
 
-	static public @Nullable RegistryEntry<PaintingVariant> GetEntry(String name){
+	static public @Nullable RegistryEntry<PaintingVariant> GetEntry(String name, Registry<PaintingVariant> registry){
 		Identifier id = Identifier.tryParse(name);
 		if (id == null)
 			return null;
 		else
-			return GetEntry(id);
+			return GetEntry(id, registry);
 	}
-	static public @Nullable RegistryEntry<PaintingVariant> GetEntry(Identifier id){
-		var variant = Registries.PAINTING_VARIANT.getOrEmpty(id);
+	static public @Nullable RegistryEntry<PaintingVariant> GetEntry(Identifier id, Registry<PaintingVariant> registry){
+		var variant = registry.getOrEmpty(id);
 		if (variant.isEmpty())
 			return null;
 		else
-			return Registries.PAINTING_VARIANT.getEntry(variant.get());
+			return registry.getEntry(variant.get());
 	}
 
 	public boolean IsMissingno(){

--- a/src/main/java/tk/estecka/nokebab/PaintingState.java
+++ b/src/main/java/tk/estecka/nokebab/PaintingState.java
@@ -8,18 +8,18 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
 /**
- * Represents the in-memory state of a PaintingEntity based on its variant. This
- * state varies greatly depending on whether the painting is a Missingno or not.
+ * Represents  the in-memory state  of  a PaintingEntity  based on  its intended
+ * variant, and whether it's a missingno.
  * 
- * If the painting variant  is valid, missingName will be empty (not null!), and
+ * If the intended variant  is valid, missingName will be empty (not null!), and
  * activeVariant represents the intended variant. missingName can never be null,
  * because it is not a valid value for the DataTracker to hold.
  * 
- * If the painting variant  is missing, missingName will  represent the intended
+ * If the intended variant  is missing, missingName will  represent the intended
  * variant, and  activeVariant  will  serve as  the  placeholder  which will  be
- * visible to vanilla clients. The  placeholder variant  should be set to kebab;
- * nothing dire  will  happen if it's not, but it being  otherwise  can indicate
- * that something unexpected occured.
+ * visible to vanilla clients. By convention, the placeholder variant  should be
+ * set to {@link RegistryUtil#GetFallback}; nothing bad will happen if it's not,
+ * but it being otherwise can indicate that something unexpected occured.
  */
 public record PaintingState (@NotNull String missingName, @NotNull RegistryEntry<PaintingVariant> activeVariant)
 {
@@ -33,7 +33,7 @@ public record PaintingState (@NotNull String missingName, @NotNull RegistryEntry
 		if (entry != null)
 			return new PaintingState("", entry);
 		else
-			return new PaintingState(name, registry.getDefaultEntry().orElseThrow());
+			return new PaintingState(name, RegistryUtil.GetFallback(registry));
 	}
 
 	static public @Nullable RegistryEntry<PaintingVariant> GetEntry(String name, Registry<PaintingVariant> registry){

--- a/src/main/java/tk/estecka/nokebab/RegistryUtil.java
+++ b/src/main/java/tk/estecka/nokebab/RegistryUtil.java
@@ -1,0 +1,23 @@
+package tk.estecka.nokebab;
+
+import net.minecraft.entity.decoration.painting.PaintingVariant;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+public class RegistryUtil
+{
+	/**
+	 * May not be the default Id depending on teh loaded paintings.
+	 * @return
+	 */
+	@Deprecated
+	static public Identifier GetDefaultId(){
+		return Identifier.of("minecraft", "alban");
+	}
+
+	static public Registry<PaintingVariant> PaintingsOf(World world){
+		return world.getRegistryManager().get(RegistryKeys.PAINTING_VARIANT);
+	}
+}

--- a/src/main/java/tk/estecka/nokebab/RegistryUtil.java
+++ b/src/main/java/tk/estecka/nokebab/RegistryUtil.java
@@ -10,7 +10,7 @@ import net.minecraft.world.World;
 public class RegistryUtil
 {
 	/**
-	 * Seeks the smallest painting existing painting, to serve as fallback.
+	 * Seeks the smallest existing painting, to serve as fallback.
 	 * Returns immediately upon finding a 1x1 painting.
 	 */
 	static public RegistryEntry<PaintingVariant> GetFallback(Registry<PaintingVariant> registry){

--- a/src/main/java/tk/estecka/nokebab/RegistryUtil.java
+++ b/src/main/java/tk/estecka/nokebab/RegistryUtil.java
@@ -3,18 +3,39 @@ package tk.estecka.nokebab;
 import net.minecraft.entity.decoration.painting.PaintingVariant;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 
 public class RegistryUtil
 {
 	/**
-	 * May not be the default Id depending on teh loaded paintings.
-	 * @return
+	 * Seeks the smallest painting existing painting, to serve as fallback.
+	 * Returns immediately upon finding a 1x1 painting.
 	 */
-	@Deprecated
-	static public Identifier GetDefaultId(){
-		return Identifier.of("minecraft", "alban");
+	static public RegistryEntry<PaintingVariant> GetFallback(Registry<PaintingVariant> registry){
+		RegistryEntry<PaintingVariant> result = null;
+		int bestFit = Integer.MAX_VALUE;
+
+		for (var entry : registry.getIndexedEntries()){
+			int surface = entry.value().getArea();
+			if (surface == 1)
+				return entry;
+
+			if (surface < bestFit){
+				result = entry;
+				bestFit = surface;
+			}
+		}
+
+		if (result == null)
+			throw new RuntimeException("Empty painting registry");
+
+		return result;
+	}
+
+	static public Identifier GetFallbackId(Registry<PaintingVariant> registry){
+		return GetFallback(registry).getKey().get().getValue();
 	}
 
 	static public Registry<PaintingVariant> PaintingsOf(World world){

--- a/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityMixin.java
+++ b/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityMixin.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.decoration.AbstractDecorationEntity;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
 import net.minecraft.entity.decoration.painting.PaintingVariant;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.registry.Registry;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import tk.estecka.nokebab.IPaintingEntityDuck;
@@ -21,6 +23,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
 import static tk.estecka.nokebab.RegistryUtil.*;
 
 @Unique
@@ -47,6 +52,10 @@ implements IPaintingEntityDuck
 	@Shadow public abstract void setVariant(RegistryEntry<PaintingVariant> variant);
 
 
+/******************************************************************************/
+/* # Interface                                                                */
+/******************************************************************************/
+
 	@Override
 	public @NotNull String	nokebab$GetMissingName(){
 		return NoKebab.areCustomTrackersEnabled() ? this.dataTracker.get(MISSING_TRACKER) : MISSING_VARIANT;
@@ -70,6 +79,10 @@ implements IPaintingEntityDuck
 	}
 
 
+/******************************************************************************/
+/* # Lifecycle                                                                */
+/******************************************************************************/
+
 	@Inject( method="initDataTracker", at=@At("HEAD") )
 	private void	InitMissingTracker(DataTracker.Builder builder, CallbackInfo info){
 		if (NoKebab.areCustomTrackersEnabled())
@@ -85,36 +98,46 @@ implements IPaintingEntityDuck
 		}
 	}
 
-	@WrapOperation( method="writeCustomDataToNbt", at=@At(value="INVOKE", target="net/minecraft/entity/decoration/painting/PaintingEntity.writeVariantToNbt (Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/registry/entry/RegistryEntry;)V") )
-	private void	WriteMissingVariantToNBT(NbtCompound nbt, RegistryEntry<PaintingVariant> entry, Operation<Void> original) {
-		final String missingName = this.nokebab$GetMissingName();
 
-		if (missingName.isEmpty())
-			original.call(nbt, entry);
+/******************************************************************************/
+/* # Serialization                                                            */
+/******************************************************************************/
+
+	@WrapOperation( method="writeCustomDataToNbt", at=@At(value="INVOKE", target="com/mojang/serialization/Codec.encodeStart(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;") )
+	private DataResult<NbtElement>	WriteMissingVariantToNBT(Codec<RegistryEntry<PaintingVariant>> codec, DynamicOps<NbtElement> ops, Object entry, Operation<DataResult<NbtElement>> original) {
+		final PaintingState state = this.nokebab$GetState();
+
+		if (!state.IsMissingno())
+			return original.call(codec, ops, entry);
 		else {
-			nbt.putString(VARIANT_NBT_KEY, missingName);
-			if (!entry.matchesId(GetDefaultId())){
+			final var defaultId = GetFallbackId(PaintingsOf(this.getWorld()));
+			if (!state.activeVariant().matchesId(defaultId)){
 				NoKebab.LOGGER.error("Painting is Missingno, but active variant is not the default one: {} {} ", this.getPos(), this.getUuid());
-				NoKebab.LOGGER.error("Known: \"{}\" Active: {} Expected: {}", missingName, entry.getKey(), GetDefaultId());
+				NoKebab.LOGGER.error("Known: \"{}\" Active: {} Expected: {}", state.missingName(), state.activeVariant().getKey(), defaultId);
 			}
+
+			NbtCompound nbt = new NbtCompound();
+			nbt.putString(VARIANT_NBT_KEY, state.missingName());
+			return DataResult.success(nbt);
 		}
 	}
 
 	@Inject( method="readCustomDataFromNbt", at=@At("TAIL") )
 	private void	preserveMissingVariantFromNBT(NbtCompound nbt, CallbackInfo info){
-		String nbtString = nbt.getString(VARIANT_NBT_KEY);
-		if (nbtString.isEmpty())
+		String variantName = nbt.getString(VARIANT_NBT_KEY);
+		if (variantName.isEmpty())
 			return;
 
-		Identifier nbtId = Identifier.tryParse(nbtString);
+		final Registry<PaintingVariant> registry = PaintingsOf(this.getWorld());
+		Identifier nbtId = Identifier.tryParse(variantName);
 		boolean valid = (nbtId != null);
-		boolean exists = valid && PaintingsOf(this.getWorld()).containsId(nbtId);
+		boolean exists = valid && registry.containsId(nbtId);
 		if (!valid)
-			NoKebab.LOGGER.warn("Painting with malformed ID: \"{}\" {} {}", nbtString, this.getPos(), this.getUuid());
+			NoKebab.LOGGER.warn("Painting with malformed ID: \"{}\" {} {}", variantName, this.getPos(), this.getUuid());
 		else if (!exists)
-			NoKebab.LOGGER.warn("Painting with missing ID: \"{}\" {} {}", nbtString, this.getPos(), this.getUuid());
+			NoKebab.LOGGER.warn("Painting with missing ID: \"{}\" {} {}", variantName, this.getPos(), this.getUuid());
 
 		if (!valid || !exists)
-			this.nokebab$SetMissingName(nbtString);
+			this.nokebab$SetState(PaintingState.ForName(variantName, registry));
 	}
 }

--- a/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityMixin.java
+++ b/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityMixin.java
@@ -7,7 +7,6 @@ import net.minecraft.entity.decoration.AbstractDecorationEntity;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
 import net.minecraft.entity.decoration.painting.PaintingVariant;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import tk.estecka.nokebab.IPaintingEntityDuck;
@@ -22,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import static tk.estecka.nokebab.RegistryUtil.*;
 
 @Unique
 @Mixin(PaintingEntity.class)
@@ -93,9 +93,9 @@ implements IPaintingEntityDuck
 			original.call(nbt, entry);
 		else {
 			nbt.putString(VARIANT_NBT_KEY, missingName);
-			if (!entry.matchesId(Registries.PAINTING_VARIANT.getDefaultId())){
+			if (!entry.matchesId(GetDefaultId())){
 				NoKebab.LOGGER.error("Painting is Missingno, but active variant is not the default one: {} {} ", this.getPos(), this.getUuid());
-				NoKebab.LOGGER.error("Known: \"{}\" Active: {}", missingName, entry.getKey());
+				NoKebab.LOGGER.error("Known: \"{}\" Active: {} Expected: {}", missingName, entry.getKey(), GetDefaultId());
 			}
 		}
 	}
@@ -108,7 +108,7 @@ implements IPaintingEntityDuck
 
 		Identifier nbtId = Identifier.tryParse(nbtString);
 		boolean valid = (nbtId != null);
-		boolean exists = valid && Registries.PAINTING_VARIANT.containsId(nbtId);
+		boolean exists = valid && PaintingsOf(this.getWorld()).containsId(nbtId);
 		if (!valid)
 			NoKebab.LOGGER.warn("Painting with malformed ID: \"{}\" {} {}", nbtString, this.getPos(), this.getUuid());
 		else if (!exists)

--- a/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityRendererMixin.java
+++ b/src/main/java/tk/estecka/nokebab/mixin/PaintingEntityRendererMixin.java
@@ -35,7 +35,7 @@ import tk.estecka.nokebab.IPaintingEntityDuck;
 public abstract class PaintingEntityRendererMixin 
 extends EntityRenderer<PaintingEntity>
 {
-	static private final Identifier MISSINGNO_ID = new Identifier("nokebab", "missingno");
+	static private final Identifier MISSINGNO_ID = Identifier.of("nokebab", "missingno");
 
 
 	private PaintingEntityRendererMixin(){ super(null); }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,8 +23,8 @@
 		"no-kebab.mixins.json"
 	],
 	"depends": {
-		"minecraft": "^1.20.5",
-		"fabricloader": ">=0.15.10",
+		"minecraft": "~1.21",
+		"fabricloader": ">=0.15.11",
 		"fabric-api": "*",
 		"java": ">=21"
 	}


### PR DESCRIPTION
- Nokebab now enforces the smallest possible variant as a placeholder, both when loading a chunk or when using an item.
- Overall refactors to be able to handle the dynamic registry.